### PR TITLE
Added patch for gentoos strict multilib

### DIFF
--- a/games-util/vinegar/files/vinegar-multilib.patch
+++ b/games-util/vinegar/files/vinegar-multilib.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 8d74d76..20a7743 100644
+--- a/Makefile
++++ b/Makefile
+@@ -6,7 +6,7 @@ PREFIX      ?= /usr
+ DATAPREFIX  = $(PREFIX)/share/vinegar
+ APPPREFIX   = $(PREFIX)/share/applications
+ ICONPREFIX  = $(PREFIX)/share/icons/hicolor
+-LIBPREFIX   = $(PREFIX)/lib
++LIBPREFIX   = $(PREFIX)/lib64
+ LAYERPREFIX = $(PREFIX)/share/vulkan/explicit_layer.d
+ 
+ CXX ?= c++

--- a/games-util/vinegar/vinegar-1.8.1.ebuild
+++ b/games-util/vinegar/vinegar-1.8.1.ebuild
@@ -30,6 +30,10 @@ BDEPEND="
     >=dev-lang/go-1.22
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-multilib.patch"
+)
+
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then
 		git-r3_src_unpack

--- a/games-util/vinegar/vinegar-9999.ebuild
+++ b/games-util/vinegar/vinegar-9999.ebuild
@@ -30,6 +30,10 @@ BDEPEND="
     >=dev-lang/go-1.22
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-multilib.patch"
+)
+
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then
 		git-r3_src_unpack


### PR DESCRIPTION
Vinegar doesnt install if gentoo is enforcing multilib strict. https://github.com/vinegarhq/vinegar/issues/577